### PR TITLE
Cargo.toml: version update to allow pasta_curves 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cuda-mobile = []
 [dependencies]
 semolina = "~0.1.2"
 sppark = "~0.1.2"
-pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"] }
+pasta_curves = { version = ">=0.3.1, <=0.5", features = ["repr-c"] }
 
 [build-dependencies]
 cc = "^1.0.70"


### PR DESCRIPTION
Tested on both Cuda and OpenCL using the sister upgrade PR : https://github.com/microsoft/Nova/pull/162
(and those on Lurk, and Nova-Scotia …)